### PR TITLE
improved windows support

### DIFF
--- a/slime-helper.lisp
+++ b/slime-helper.lisp
@@ -28,7 +28,12 @@
       ;; windows emacs can map ~ all over the place, see 
       ;; http://www.gnu.org/software/emacs/windows/big.html#index-HOME-directory-49
       ;; emit elisp so emacs calculates the right path to slime-helper.el based on where it thinks ~ is
-      (format t "  (load (expand-file-name (file-relative-name ~S (getenv \"HOME\"))))~%" (namestring target)))
+      (format t "  (load ~S)~%" 
+	      (concatenate 'string
+			   #-lispworks (pathname-device (user-homedir-pathname))
+			   #+lispworks (pathname-host (user-homedir-pathname))
+			   ":"
+			   (namestring target))))
     #-win32
     (let ((enough (enough-namestring target (user-homedir-pathname))))
       (unless (equal (pathname enough) target)


### PR DESCRIPTION
added a #+win32 and the elisp to get emacs to figure out the right path to load instead of lisp.  

Looking at http://www.gnu.org/software/emacs/windows/big.html#index-HOME-directory-49, emacs on windows has a lot of places where it might put "~".  I think this patch basically ports the lisp path calculation code to elisp.  Instead of enough-namestring, uses file-relative-name (http://www.delorie.com/gnu/docs/elisp-manual-21/elisp_397.html)
