### PR TITLE
determine the absolute path to slime-helper.el entirely in CL

### DIFF
--- a/slime-helper.lisp
+++ b/slime-helper.lisp
@@ -28,7 +28,12 @@
       ;; windows emacs can map ~ all over the place, see 
       ;; http://www.gnu.org/software/emacs/windows/big.html#index-HOME-directory-49
       ;; emit elisp so emacs calculates the right path to slime-helper.el based on where it thinks ~ is
-      (format t "  (load (expand-file-name (file-relative-name ~S (getenv \"HOME\"))))~%" (namestring target)))
+      (format t "  (load ~S)~%" 
+	      (concatenate 'string
+			   #-lispworks (pathname-device (user-homedir-pathname))
+			   #+lispworks (pathname-host (user-homedir-pathname))
+			   ":"
+			   (namestring target))))
     #-win32
     (let ((enough (enough-namestring target (user-homedir-pathname))))
       (unless (equal (pathname enough) target)

--- a/slime-helper.lisp
+++ b/slime-helper.lisp
@@ -22,9 +22,16 @@
     (ensure-installed  (find-system "swank"))
     (format t "~&slime-helper.el installed in ~S~%~%"
             (namestring target))
+    (format t "To use, add this to your ~~/.emacs:~%~%")
+    #+win32
+    (progn
+      ;; windows emacs can map ~ all over the place, see 
+      ;; http://www.gnu.org/software/emacs/windows/big.html#index-HOME-directory-49
+      ;; emit elisp so emacs calculates the right path to slime-helper.el based on where it thinks ~ is
+      (format t "  (load (expand-file-name (file-relative-name ~S (getenv \"HOME\"))))~%" (namestring target)))
+    #-win32
     (let ((enough (enough-namestring target (user-homedir-pathname))))
       (unless (equal (pathname enough) target)
         (setf enough (format nil "~~/~A" enough)))
-      (format t "To use, add this to your ~~/.emacs:~%~%")
-      (format t "  (load (expand-file-name ~S))~%" enough)
-      (format t "  (require 'slime)~%~%"))))
+      (format t "  (load (expand-file-name ~S))~%" enough))
+    (format t "  (require 'slime)~%~%")))


### PR DESCRIPTION
That last patch didn't work on startup.  Apparently (getenv "HOME") in elisp was returning "C:\Program Files\Emacs 22.3\" during emacs initialization, and then the right value later on if you evaluate it manually.

This patch determines the whole path in CL, so emacs just deals with a LOAD.  Uses PATHNAME-DEVICE or PATHNAME-HOST if you're on lispworks.
