### PR TITLE
Setup slime contribs if set before loading.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,8 @@ to your Emacs load-path.
 
 In your ~/.emacs, you could have something like this:
 
+  ;; To customize the loaded contribs, set slime-contribs like so:
+  ;; (setq slime-contribs '(slime-fancy))
   (load (expand-file-name "~/quicklisp/slime-helper.el"))
   (setq inferior-lisp-program "sbcl")
 

--- a/slime-helper-template.el
+++ b/slime-helper-template.el
@@ -35,4 +35,6 @@
   (setq slime-backend (expand-file-name "swank-loader.lisp"
                                         quicklisp-slime-directory))
   (setq slime-path quicklisp-slime-directory)
-  (slime-setup '(slime-fancy)))
+  (if (boundp 'slime-contribs)
+      (slime-setup slime-contribs)
+    (slime-setup '(slime-fancy))))


### PR DESCRIPTION
In order to allow a customizable set of slime contribs to be setup
when loading the helper, check whether slime-contribs has been set,
and if so pass that list to slime-setup; otherwise fall back on the
default '(slime-fancy) list.

slime-setup will use slime-contribs if it is called with no arguments,
and the default value for slime-contribs is '(slime-fancy), so this
could be done by calling slime-setup with no arguments. However, I'm
not certain if that is the case with all relevant versions of slime,
and we are already relying on the explicit-argument form, so that's
the conservative choice here.

This should fix #10, if it's acceptable.