### PR TITLE
Use installed slime over bundled version, if available

### DIFF
--- a/slime-helper-template.el
+++ b/slime-helper-template.el
@@ -29,10 +29,14 @@
 (defun quicklisp-slime-helper-slime-directory ()
   (quicklisp-slime-helper-system-directory "swank"))
 
-(let* ((quicklisp-slime-directory (quicklisp-slime-helper-slime-directory)))
-  (add-to-list 'load-path quicklisp-slime-directory)
-  (require 'slime-autoloads)
-  (setq slime-backend (expand-file-name "swank-loader.lisp"
-                                        quicklisp-slime-directory))
-  (setq slime-path quicklisp-slime-directory)
-  (slime-setup '(slime-fancy)))
+(let* ((installed-slime (locate-library "slime"))
+       (quicklisp-slime-directory (if installed-slime
+                                      (file-name-directory (locate-library "slime"))
+                                    (quicklisp-slime-helper-slime-directory))))
+  (if (not installed-slime)
+      (add-to-list 'load-path quicklisp-slime-directory))
+(require 'slime-autoloads)
+(setq slime-backend (expand-file-name "swank-loader.lisp"
+                                      quicklisp-slime-directory))
+(setq slime-path quicklisp-slime-directory)
+(slime-setup '(slime-fancy))


### PR DESCRIPTION
If the bundled version of slime differs from the installed version found by emacs, then a version error occurs. This pull requests confirms if a version of slime is installed, and if so then that is used rather than the bundled version.

I'm quite new to elisp - I am happy to receive any constructive criticism of my code!